### PR TITLE
Fix partial system stop logic

### DIFF
--- a/src/init/system.clj
+++ b/src/init/system.clj
@@ -20,7 +20,9 @@
    (stop-system system graph selectors nil))
   ([system graph selectors exception]
    (reduce (fn [ex [k c]]
-             (stop-component c (system k) ex))
+             (if (contains? system k)
+               (stop-component c (system k) ex)
+               ex))
            exception
            (graph/reverse-dependency-order graph selectors))))
 


### PR DESCRIPTION
This PR fixes a problem where: in a partial system, during system stop, `core/stop` will attempt to shutdown components that haven't been started. 

The added test case can reproduce the problem :) 

(IMO this fix "suffice" but not the best, the best fix is to calculate a sub-graph based on running system + entire graph. Perhaps that's for another day.) 